### PR TITLE
allow to configure preferredAuthentications

### DIFF
--- a/src/main/java/com/github/robtimus/filesystems/sftp/SFTPEnvironment.java
+++ b/src/main/java/com/github/robtimus/filesystems/sftp/SFTPEnvironment.java
@@ -72,6 +72,7 @@ public class SFTPEnvironment implements Map<String, Object>, Cloneable {
     private static final String SERVER_ALIVE_COUNTMAX = "serverAliveCountMax"; //$NON-NLS-1$
     private static final String IDENTITY_REPOSITORY = "identityRepository"; //$NON-NLS-1$
     private static final String HOST_KEY_REPOSITORY = "hostKeyRepository"; //$NON-NLS-1$
+    private static final String HOST_PREFERRED_AUTHENTICATIONS = "preferredAuthentications"; //$NON-NLS-1$
     // don't support port forwarding, X11
 
     // ChannelSession
@@ -485,6 +486,11 @@ public class SFTPEnvironment implements Map<String, Object>, Cloneable {
         HostKeyRepository hostKeyRepository = FileSystemProviderSupport.getValue(this, HOST_KEY_REPOSITORY, HostKeyRepository.class, null);
         if (hostKeyRepository != null) {
             session.setHostKeyRepository(hostKeyRepository);
+        }
+
+        String preferredAuthentications = FileSystemProviderSupport.getValue(this, HOST_PREFERRED_AUTHENTICATIONS, String.class, null);
+        if (preferredAuthentications != null) {
+            session.setConfig("PreferredAuthentications", preferredAuthentications); //$NON-NLS-1$
         }
     }
 


### PR DESCRIPTION
One can configure such JSch configurations using the static Jsch.setConfig(), however, I prefer to being able to configure things not in global.

Instead of trying to pass down each and every configuration parameter to JSch we also can prefix our configuration parameters with "jsch_" and strip that off and pass the configuration down to JSch then.
This would allow to configure whatever JSch allows to configure.

If you would like to go the other way, just let me know and I'll prepare another pull request.

Thanks for your work! 